### PR TITLE
Format shortname and mode evenly

### DIFF
--- a/src/Route.js
+++ b/src/Route.js
@@ -32,7 +32,8 @@ class Route {
 
 function maxFieldLength(route, fieldName) {
   return route.legs.reduce((prevMax, route) => {
-    const currLength = get(route, fieldName, "").length
+    const field = get(route, fieldName, "")
+    const currLength = field && field.length
     return currLength > prevMax ? currLength : prevMax
   }, 0)
 }
@@ -58,9 +59,9 @@ function printLeg(leg, maxRouteNameLength, maxModeLength) {
   const color = getColorByMode(leg.mode)
   const emoji = getEmojiByMode(leg.mode)
 
-  const sortName = get(leg, 'route.shortName', '')
-  const shortNamePadChar = sortName.length === 0 ? '.' : ' '
-  console.log(color('  | '), `${formatTime(leg.startTime)} - ${formatTime(leg.endTime)}`, emoji, color(padEnd(leg.mode, maxModeLength)), bold(padEnd(sortName, maxRouteNameLength, shortNamePadChar)), `-> ${leg.to.name}`)
+  const shortName = get(leg, 'route.shortName', '')
+  const shortNamePadChar = (!shortName || shortName.length) === 0 ? '.' : ' '
+  console.log(color('  | '), `${formatTime(leg.startTime)} - ${formatTime(leg.endTime)}`, emoji, color(padEnd(leg.mode, maxModeLength)), bold(padEnd(shortName, maxRouteNameLength, shortNamePadChar)), `-> ${leg.to.name}`)
 }
 
 export default Route

--- a/src/Route.js
+++ b/src/Route.js
@@ -1,6 +1,6 @@
 import {bold} from 'chalk'
 import {getRoutes} from './hsl-api/hsl-api'
-import {head, last} from 'lodash'
+import {head, last, get, padEnd} from 'lodash'
 
 import {getColorByMode, getEmojiByMode, formatTime, formatDuration} from './view-utils'
 
@@ -30,13 +30,23 @@ class Route {
   }
 }
 
+function maxFieldLength(route, fieldName) {
+  return route.legs.reduce((prevMax, route) => {
+    const currLength = get(route, fieldName, "").length
+    return currLength > prevMax ? currLength : prevMax
+  }, 0)
+}
 function printRoute(route) {
   console.log('')
   const start = head(route.legs).startTime
   const end = last(route.legs).endTime
 
   printRouteInformation(start, end, route.duration)
-  route.legs.forEach(printLeg)
+
+  const maxRouteNameLength = maxFieldLength(route, 'route.shortName');
+  const maxModeLength = maxFieldLength(route, 'mode');
+
+  route.legs.forEach(leg => printLeg(leg, maxRouteNameLength, maxModeLength))
   console.log('')
 }
 
@@ -44,15 +54,13 @@ function printRouteInformation(start, end, duration) {
   console.log(`${formatTime(start)} - ${formatTime(end)} (${formatDuration(duration)})`)
 }
 
-function printLeg(leg) {
+function printLeg(leg, maxRouteNameLength, maxModeLength) {
   const color = getColorByMode(leg.mode)
   const emoji = getEmojiByMode(leg.mode)
 
-  if (leg.route && leg.route.shortName) {
-    console.log(color('  | '), `${formatTime(leg.startTime)} - ${formatTime(leg.endTime)}`, emoji, color(leg.mode), bold(leg.route.shortName), `-> ${leg.to.name}`)
-  } else {
-    console.log(color('  | '), `${formatTime(leg.startTime)} - ${formatTime(leg.endTime)}`, emoji, color(leg.mode), `-> ${leg.to.name}`)
-  }
+  const sortName = get(leg, 'route.shortName', '')
+  const shortNamePadChar = sortName.length === 0 ? '.' : ' '
+  console.log(color('  | '), `${formatTime(leg.startTime)} - ${formatTime(leg.endTime)}`, emoji, color(padEnd(leg.mode, maxModeLength)), bold(padEnd(sortName, maxRouteNameLength, shortNamePadChar)), `-> ${leg.to.name}`)
 }
 
 export default Route


### PR DESCRIPTION
Format route mode ('WALK', 'RAIL', 'BUS', 'TRAM', 'SUBWAY', 'FERRY') and route shortname (I, K, A, E, ...) evenly with padding

Not sure if this is a change towards better user experience. It might be a bit easier to read..

<img width="933" alt="new-vs-old-formatting" src="https://cloud.githubusercontent.com/assets/3646062/20361988/71f68e82-ac42-11e6-8f03-fa776edd7a6e.png">
